### PR TITLE
issue/5919 SSL Server Disable in Test

### DIFF
--- a/src/test/resources/config/application.properties
+++ b/src/test/resources/config/application.properties
@@ -1,0 +1,1 @@
+server.ssl.enabled=false


### PR DESCRIPTION
Results:
[INFO]
[INFO] Tests run: 35, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO]
[INFO] --- jacoco-maven-plugin:0.8.4:report (post-unit-test) @ viptela-sdwan-driver ---
[INFO] Loading execution data file C:\project\viptela-sdwan-driver\target\test-results\coverage\jacoco\jacoco.exec
[INFO] Analyzed bundle 'viptela-sdwan-driver' with 12 classes
[INFO]
[INFO] --- maven-jar-plugin:3.2.2:jar (default-jar) @ viptela-sdwan-driver ---
[INFO] Building jar: C:\project\viptela-sdwan-driver\target\viptela-sdwan-driver-1.0.1-SNAPSHOT.jar
[INFO]
[INFO] --- spring-boot-maven-plugin:2.6.8:repackage (repackage) @ viptela-sdwan-driver ---
[INFO] Replacing main artifact with repackaged archive
[INFO]
[INFO] --- sortpom-maven-plugin:2.8.0:sort (default) @ viptela-sdwan-driver ---
[INFO] Sorting file C:\project\viptela-sdwan-driver\pom.xml
[INFO] Pom file is already sorted, exiting
[INFO]
[INFO] --- maven-install-plugin:2.5.2:install (default-install) @ viptela-sdwan-driver ---
[INFO] Installing C:\project\viptela-sdwan-driver\target\viptela-sdwan-driver-1.0.1-SNAPSHOT.jar to C:\Users\gsiddala\.m2\repository\com\ibm\viptela-sdwan-driver\1.0.1-SNAPSHOT\viptela-sdwan-driver-1.0.1-SNAPSHOT.jar
[INFO] Installing C:\project\viptela-sdwan-driver\pom.xml to C:\Users\gsiddala\.m2\repository\com\ibm\viptela-sdwan-driver\1.0.1-SNAPSHOT\viptela-sdwan-driver-1.0.1-SNAPSHOT.pom
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  33.996 s
[INFO] Finished at: 2022-09-29T15:04:07+05:30
[INFO] ------------------------------------------------------------------------
